### PR TITLE
Add teacher login endpoint and credentials file for admin mode

### DIFF
--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,10 @@
+[
+  {
+    "username": "teacher1",
+    "password": "password123"
+  },
+  {
+    "username": "teacher2",
+    "password": "securepass"
+  }
+]


### PR DESCRIPTION
Implements a simple username/password login for teachers, with credentials stored in teachers.json. Adds a /login endpoint to support admin mode as described in Issue #8.